### PR TITLE
temporary working replacement of docker-dependencies

### DIFF
--- a/docker-instructions.md
+++ b/docker-instructions.md
@@ -14,10 +14,10 @@
 
 *Getting Started*
 
- 1. Type: `docker pull arogi/docker-dependencies`  
+ 1. Type: `docker pull arogi/temp-arogi-demos`  
     to grab the latest Arogi Docker image.
 
- 2. Type: `docker run -it -p 80:80 -d -v ~/repos/arogi-demos/:/var/www/html arogi/docker-dependencies /bin/bash`  
+ 2. Type: `docker run -it -p 80:80 -d -v ~/repos/arogi-demos/:/var/www/html arogi/temp-arogi-demos /bin/bash`  
     In that statement, replace `~/repos/arogi-demos/` with the pathname to the local directory of the cloned repository.
     Data used are in the /data directory. To change data files, modify the path in index.html, lines 86/87.
 
@@ -40,4 +40,4 @@
 
  3. To remove the container, type: `docker rm container_name`
 
- 4. To remove the image, type: `docker rmi image_name` (e.g., `docker rmi arogi/docker-dependencies`)
+ 4. To remove the image, type: `docker rmi image_name` (e.g., `docker rmi arogi/temp-arogi-demos`)


### PR DESCRIPTION
Since or-tools installations are currently failing with its new build, this reverts to the next most-recent working image (arogi/temp-arogi-demos).